### PR TITLE
Add node_exporter

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -242,6 +242,7 @@
 - url: https://github.com/cloudfoundry-community/sawmill-boshrelease
 - url: https://github.com/SAP/ipsec-release
 - url: https://github.com/cloudfoundry-community/prometheus-boshrelease
+- url: https://github.com/cloudfoundry-community/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease
 - url: https://github.com/cloudfoundry-incubator/garden-windows-bosh-release
 - url: https://github.com/cloudfoundry/grootfs-release


### PR DESCRIPTION
node_exporter is commonly used as an addon to gather detailed VM metrics