### PR TITLE
Add concourse-windows-worker-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -142,6 +142,9 @@
   categories: [ci, homepage]
   homepage: true
   min_version: 0.11
+- url: https://github.com/pivotal-cf-experimental/concourse-windows-worker-release
+  categories: [ci]
+  min_version: 3.3.3
 
 # Testing
 - url: https://github.com/cppforlife/turbulence-release


### PR DESCRIPTION
This release enables BOSH deploying a Windows Concourse worker