### PR TITLE
Add cf-rabbitmq-multitenant-broker-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -181,6 +181,9 @@
   categories: [homepage]
   homepage: true
   min_version: 54
+- url: https://github.com/pivotal-cf/cf-rabbitmq-multitenant-broker-release
+  categories: [homepage]
+  homepage: true
 - url: https://github.com/cloudfoundry-community/admin-ui-boshrelease
   min_version: 4
 - url: https://github.com/pivotal-cf/cf-redis-release


### PR DESCRIPTION
Hi,

We have open sourced our `cf-rabbitmq-multitenant-broker-release` and would like to distributed that on bosh.io, the same way we distribute `cf-rabbitmq-release`.

Cheers