### PR TITLE
Add windows2016fs-online-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -71,6 +71,8 @@
   min_version: 191
 - url: https://github.com/cloudfoundry/cflinuxfs2-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry-incubator/windows2016fs-online-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry/cf-mysql-release
   categories: [cf-core, homepage]
   homepage: true


### PR DESCRIPTION
Required for `cf-deployment` to be able to use a rootfs release for the `windows2016` stack.

Release repo: https://github.com/cloudfoundry-incubator/windows2016fs-online-release