### PR TITLE
Replace loggregator with loggregator-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -85,7 +85,7 @@
   min_version: 1.8.0
 - url: https://github.com/cloudfoundry-incubator/consul-release
   categories: [cf-core]
-- url: https://github.com/cloudfoundry/loggregator
+- url: https://github.com/cloudfoundry/loggregator-release
   categories: [cf-core]
   min_version: 9
 - url: https://github.com/cloudfoundry/garden-linux-release

--- a/index.yml
+++ b/index.yml
@@ -87,7 +87,7 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/loggregator-release
   categories: [cf-core]
-  min_version: 9
+  min_version: 99
 - url: https://github.com/cloudfoundry/garden-linux-release
   categories: [cf-core]
   min_version: 0.333.0


### PR DESCRIPTION
We want to rename the repo from github.com/cloudfoundry/loggregator to github.com/cloudfoundry/loggregator-release.

We are unsure how to get the `worker` to start polling the new URL.