### PR TITLE
Add loggregator-legacy-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -88,6 +88,9 @@
 - url: https://github.com/cloudfoundry/loggregator-release
   categories: [cf-core]
   min_version: 99
+- url: https://github.com/cloudfoundry/loggregator-legacy-release
+  categories: [cf-core]
+  min_version: 99
 - url: https://github.com/cloudfoundry/garden-linux-release
   categories: [cf-core]
   min_version: 0.333.0


### PR DESCRIPTION
This is a "new" repo that will only ever have loggregator v99.x releases. This is necessary for the cf-release to cf-deployment upgrade path.