### PR TITLE
Add windows-tools-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -296,3 +296,4 @@
   min_version: 3.20.0
 - url: https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-boshrelease
   min_version: 1.5.0
+- url: https://github.com/cloudfoundry-incubator/windows-tools-release


### PR DESCRIPTION
windows-tools-release is a release for installing miscellaneous packages on a BOSH deployed Windows VM (e.g. ruby, docker, etc.)  