### PR TITLE
Add silk release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -125,7 +125,7 @@
   min_version: 0.2.0
 - url: https://github.com/cloudfoundry/silk-release
   categories: [cf-core]
-  min_version: 2.0.0
+  min_version: 0.1.0
 
 # CF buildpacks
 - url: https://github.com/cloudfoundry/staticfile-buildpack-release

--- a/index.yml
+++ b/index.yml
@@ -123,6 +123,9 @@
 - url: https://github.com/cloudfoundry/cf-app-sd-release
   categories: [cf-core]
   min_version: 0.2.0
+- url: https://github.com/cloudfoundry/silk-release
+  categories: [cf-core]
+  min_version: 2.0.0
 
 # CF buildpacks
 - url: https://github.com/cloudfoundry/staticfile-buildpack-release


### PR DESCRIPTION
We would like for bosh.io to pick up `silk-release`, which has been split out from `cf-networking-release`.

Cheers,
Angela