### PR TITLE
added minecraft-boshrelease

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -322,3 +322,5 @@
   min_version: 0
 - url: https://github.com/cloudfoundry/loggregator-agent-release
   min_version: 1.0
+- url: https://github.com/martyca/minecraft-boshrelease
+  min_version: 1.0.0


### PR DESCRIPTION
i've created a minecraft boshrelease to use as a teaching and promotion tool.
it might seem somewhat "frivolous" but i feel that using something "playfull" can really help when trying to promote new technologies and ideas,
the release can work with persistent disks which is cool because it allows me to modify the minecraft world, destroy the deployment, salvage the orphaned disk, attach it to a new deployment, and show people that the little cabin we build is still there.
todo:
modify java startup settings with deployment properties.