### PR TITLE
Add harbor-boshrelease into index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -324,3 +324,5 @@
   min_version: 1.0
 - url: https://github.com/martyca/minecraft-boshrelease
   min_version: 1.0.0
+- url: https://github.com/vmware/harbor-boshrelease
+  min_version: 1.5.0


### PR DESCRIPTION
[Project Harbor](https://github.com/vmware/harbor/) is an enterprise-class registry server 
that stores and distributes Docker images. 
Add the following snippet into the bosh deployment manifest file to deploy Project Harbor:

```
releases:
- name: harbor-container-registry
  version: 1.5.0
  sha1: ded9ed8a5e2efadc3aed26444710d8446483bd59
  url: https://storage.googleapis.com/harbor-bosh-releases/harbor-container-registry-1.5.0.tgz
```