### PR TITLE
Added 1803 release to index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -76,6 +76,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry-incubator/windows2016fs-online-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/windows1803fs-online-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry/cf-mysql-release
   categories: [cf-core, homepage]
   homepage: true


### PR DESCRIPTION
This is the rootfs release for 1803 Windows cells. We are moving towards having 1803 cells be the default for CF Windows deployments.