### PR TITLE
Remove nfs-volume-release from cloudfoundry-incubator

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -131,9 +131,6 @@
   min_version: 8
 - url: https://github.com/cloudfoundry/statsd-injector-release
   categories: [cf-core]
-- url: https://github.com/cloudfoundry-incubator/nfs-volume-release
-  categories: [cf-core]
-  min_version: 0.0.11
 - url: https://github.com/cloudfoundry-incubator/bits-service-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/cf-app-sd-release


### PR DESCRIPTION
Only keep nfs-volume-release from cloudfoundry organization.