### PR TITLE
Add CPIs which have moved to cf org

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -33,6 +33,17 @@
   categories: [core]
 
 # CPIs
+- url: https://github.com/cloudfoundry/bosh-vsphere-cpi-release
+  categories: [cpi]
+- url: https://github.com/cloudfoundry/bosh-aws-cpi-release
+  categories: [cpi]
+- url: https://github.com/cloudfoundry/bosh-openstack-cpi-release
+  categories: [cpi]
+- url: https://github.com/cloudfoundry/bosh-azure-cpi-release
+  categories: [cpi]
+- url: https://github.com/cloudfoundry/bosh-google-cpi-release
+  categories: [cpi]
+  min_version: 24.3.0
 - url: https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release
   categories: [cpi]
 - url: https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release


### PR DESCRIPTION
VSphere, AWS, OpenStack, Azure, and google graduated to 'active'
projects and move therefore out of incubation.

We keep both locations here for a period of time (incubator as
well as cf org) and will remove the incubator entries with a
subsequent PR.