### PR TITLE
Add envoy-release to bosh.io

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -82,6 +82,7 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/envoy-release
   categories: [cf-core]
+  min_version: 0.1.0
 - url: https://github.com/cloudfoundry/cf-mysql-release
   categories: [cf-core, homepage]
   homepage: true

--- a/index.yml
+++ b/index.yml
@@ -80,6 +80,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/windows1803fs-online-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/envoy-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry/cf-mysql-release
   categories: [cf-core, homepage]
   homepage: true


### PR DESCRIPTION
The release is so we can deploy Envoy to Windows Diego Cells. Instead of keeping it as a blob in diego-release, we provide a separate release that can be co-located

cc: @natalieparellano 