### PR TITLE
Add cf-rabbitmq-smoke-tests

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -223,6 +223,8 @@
   min_version: 54
 - url: https://github.com/pivotal-cf/cf-rabbitmq-multitenant-broker-release
   min_version: 6
+- url: https://github.com/pivotal-cf/cf-rabbitmq-smoke-tests-release
+  min_version: 20.0.0
 - url: https://github.com/cloudfoundry-community/admin-ui-boshrelease
   min_version: 4
 - url: https://github.com/pivotal-cf/cf-redis-release


### PR DESCRIPTION
This bosh release is a pre-req of https://github.com/pivotal-cf/cf-rabbitmq-multitenant-broker-release, and it does not make sense to release the dependent without the dependency, as pointed out in https://github.com/pivotal-cf/cf-rabbitmq-smoke-tests-release/issues/2

Resolves https://github.com/pivotal-cf/cf-rabbitmq-smoke-tests-release/issues/2