### PR TITLE
Set minimum version of ipsec to 3

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -287,6 +287,7 @@
 - url: https://github.com/starkandwayne/bosh-errand-resource-boshrelease
 - url: https://github.com/cloudfoundry-community/sawmill-boshrelease
 - url: https://github.com/SAP/ipsec-release
+  min_version: 3
 - url: https://github.com/cloudfoundry-community/prometheus-boshrelease
 - url: https://github.com/cloudfoundry-community/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease


### PR DESCRIPTION
We moved to a different blobstore, releases 1 and 2 are no longer possible to build.