### PR TITLE
Added generic online windows rootfs release to index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -80,6 +80,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/windows1803fs-online-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/windowsfs-online-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry/envoy-release
   categories: [cf-core]
   min_version: 0.1.0


### PR DESCRIPTION
For now this adds support for the 2019 OS (similar to how [this PR](https://github.com/bosh-io/releases/pull/50)
added support for 1803), the plan is to eventually move the 1803 and 2016
rootfs's into this release so we don't have to maintain 3 seperate releases.

[#163988757]

Signed-off-by: Natalie Arellano <narellano@pivotal.io>