### PR TITLE
Add cloudfoundry/istio-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -252,6 +252,7 @@
 - url: https://github.com/cloudfoundry-community/slack-notification-resource-boshrelease
 - url: https://github.com/cloudfoundry-community/tor-boshrelease
 - url: https://github.com/cloudfoundry-incubator/cf-routing-release
+- url: https://github.com/cloudfoundry/istio-release
 - url: https://github.com/cloudfoundry-incubator/diego-docker-cache-release
 - url: https://github.com/cloudfoundry-community/git-server-release
   min_version: 3


### PR DESCRIPTION
This release contains the new Istio routing tier that the CF Networking program has been working on. It can be deployed alongside the existing Routing Release.

[#164546946]

Please let us know of any concerns.
Regards,
CF Networking