### PR TITLE
Add Eirini bosh release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -151,6 +151,9 @@
 - url: https://github.com/bosh-packages/cf-cli-release
   categories: [cf-core]
   min_version: 1.3.0
+- url: https://github.com/cloudfoundry-community/eirini-bosh-release
+  categories: [cf-core]
+  min_version: 0.0.3
 
 # CF buildpacks
 - url: https://github.com/cloudfoundry/staticfile-buildpack-release


### PR DESCRIPTION
Hi,

We are maintaining the Eirini bosh release from community @SUSE, would be nice to have it as a release on bosh.io, let me know if anything else is needed.

Thanks