### PR TITLE
update bpm-release organization

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -29,7 +29,7 @@
   categories: [core]
 - url: https://github.com/cloudfoundry/networking-release
   categories: [core]
-- url: https://github.com/cloudfoundry-incubator/bpm-release
+- url: https://github.com/cloudfoundry/bpm-release
   categories: [core]
 
 # CPIs


### PR DESCRIPTION
The `bpm-release` repository was recently moved from `cloudfoundry-incubator` to `cloudfoundry`. This change updates the release index to point at the new location.