### PR TITLE
Add the notifications-release to bosh.io

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -373,3 +373,4 @@
 - url: https://github.com/cloudfoundry/service-logs-release
   min_version: 1.0
 - url: https://github.com/pivotal-cf/telemetry-release
+- url: https://github.com/cloudfoundry-incubator/notifications-release


### PR DESCRIPTION
This is deployed in many production CF deployments and is OSS, so it should be available on bosh.io