### PR TITLE
Add quarks-gora release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -207,6 +207,9 @@
   categories: [testing]
 - url: https://github.com/pivotal-cf-experimental/bosh-lemon-release
   categories: [testing]
+- url: https://github.com/cloudfoundry-incubator/quarks-gora-release
+  categories: [testing]
+  min_version: 0.0.3
 
 # Jumpbox
 - url: https://github.com/dpb587/openvpn-bosh-release


### PR DESCRIPTION
Hi!

Quarks team here, can we have https://github.com/cloudfoundry-incubator/quarks-gora-release added to bosh.io? 

Thank you!