### PR TITLE
add external-postgres-metrics-emmiter

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -385,3 +385,4 @@
   min-version: 3
 - url: https://github.com/grapeup/filesystem-bbr-boshrelease
 - url: https://github.com/starkandwayne/awscli2-boshrelease
+- url: https://github.com/starkandwayne/external-postgres-metrics-emitter-release.git


### PR DESCRIPTION
add the external postgres metrics emmiter to bosh.io/releases from
https://github.com/starkandwayne/external-postgres-metrics-emitter-release