### PR TITLE
Add version of HAProxy BOSH release with new org

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -316,8 +316,10 @@
 - url: https://github.com/cloudfoundry-incubator/garden-windows-bosh-release
 - url: https://github.com/cloudfoundry/grootfs-release
 - url: https://github.com/cloudfoundry-community/cron-boshrelease
-- url: https://github.com/cloudfoundry-community/haproxy-boshrelease
-  min_version: 8.0.6
+- url: https://github.com/cloudfoundry/haproxy-boshrelease
+  min_version: 11.7.1
+- url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease
+  min_version: 8.1.0
 - url: https://github.com/cloudfoundry/bosh-hm-forwarder-release
   min_version: 1.0.11
 - url: https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry
@@ -329,8 +331,6 @@
 - url: https://github.com/cloudfoundry-community/etcd-cf-service-broker-boshrelease
 - url: https://github.com/flavorjones/windows-ruby-dev-tools-release
   min_version: 3
-- url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease
-  min_version: 8.1.0
 - url: https://github.com/DataDog/datadog-firehose-nozzle-release
   min_version: 62
 - url: https://github.com/vito/vault-boshrelease


### PR DESCRIPTION
HAProxy BOSH release was recently moved from the cloudfoundry-incubator org to cloudfoundry. This change:
* Adds a BOSH release for HAProxy using the path for the new org
* Removes the _very old_ Cloud Foundry community version of HAProxy BOSH Release
* Keeps the cloudfoundry-incubator (I expect this is be necessary so users can access old versions?)

Related discussion in CF Slack https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1634666203051000

Checklist for submission:

- ✅ LICENSE and NOTICE files are up to date
- ✅ at least one final release is checked in on the default repo branch (there's a `.final_builds` folder)
- ✅ of use to the general community and will be maintained
- ✅ github repo must be public
- ✅ bosh create-release must run successfully against all final releases (the blobstore needs to be public)
  - if not all final releases are valid, specify a `min_version`
- ✅ a README explaining what the repo does
- ✅ [optional] deployment manifests/ directory contains example manifest
