### PR TITLE
Add BOSH release for Varnish

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -387,3 +387,4 @@
 - url: https://github.com/grapeup/filesystem-bbr-boshrelease
 - url: https://github.com/starkandwayne/awscli2-boshrelease
 - url: https://github.com/starkandwayne/external-postgres-metrics-emitter-release
+- url: https://github.com/springernature/varnish-boshrelease


### PR DESCRIPTION
Checklist for submission:

- [x] LICENSE and NOTICE files are up to date
- [x] at least one final release is checked in on the default repo branch (there's a `.final_builds` folder)
- [x] of use to the general community and will be maintained
- [x] github repo must be public
- [x] bosh create-release must run successfully against all final releases (the blobstore needs to be public)
  - if not all final releases are valid, specify a `min_version`
- [x] a README explaining what the repo does
- [x] [optional] deployment manifests/ directory contains example manifest

Note: We created this bosh release quite a while ago and successfully use it in production along our Cloud Foundry deployment. However, we never came around to finalise the missing bits and pieces to share it properly.
But here we are, better late than never.