### PR TITLE
Add cflinuxfs4 bosh release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -79,6 +79,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/cflinuxfs3-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/cflinuxfs4-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry-incubator/windows2016fs-online-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/windows1803fs-online-release


### PR DESCRIPTION
The [cflinuxfs4 bosh release](https://github.com/cloudfoundry/cflinuxfs4-release) deploys the [cflinuxfs4 rootfs](https://github.com/cloudfoundry/cflinuxfs4).

Checklist for submission:

- [x] LICENSE and NOTICE files are up to date
- [x] at least one final release is checked in on the default repo branch (there's a `.final_builds` folder)
- [x] of use to the general community and will be maintained
- [x] github repo must be public
- [x] bosh create-release must run successfully against all final releases (the blobstore needs to be public)
  - if not all final releases are valid, specify a `min_version`
- [x] a README explaining what the repo does
- [x] [optional] deployment manifests/ directory contains example manifest
