### PR TITLE
Add Healthchecker bosh release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -106,9 +106,6 @@
 - url: https://github.com/cloudfoundry/cf-networking-release
   categories: [cf-core]
   min_version: 1.8.0
-  - url: https://github.com/cloudfoundry/healthchecker-release
-  categories: [cf-core]
-  min_version: 0.1.0
 - url: https://github.com/cloudfoundry-incubator/consul-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/loggregator-release

--- a/index.yml
+++ b/index.yml
@@ -29,6 +29,8 @@
   categories: [core]
 - url: https://github.com/cloudfoundry/networking-release
   categories: [core]
+- url: https://github.com/cloudfoundry/healthchecker-release
+  categories: [core]
 - url: https://github.com/cloudfoundry/bpm-release
   categories: [core]
 
@@ -104,6 +106,9 @@
 - url: https://github.com/cloudfoundry/cf-networking-release
   categories: [cf-core]
   min_version: 1.8.0
+  - url: https://github.com/cloudfoundry/healthchecker-release
+  categories: [cf-core]
+  min_version: 0.1.0
 - url: https://github.com/cloudfoundry-incubator/consul-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/loggregator-release


### PR DESCRIPTION
The [Healthchecker bosh release](https://github.com/cloudfoundry/Healthchecker) is being moved out of [cf-networking-helpers/healthchecker](https://github.com/cloudfoundry/cf-networking-helpers/tree/main/healthchecker) to address dependency conflicts in the future.

Checklist for submission:

- [x] LICENSE and NOTICE files are up to date
- [x] at least one final release is checked in on the default repo branch (there's a `.final_builds` folder)
- [x] of use to the general community and will be maintained
- [x] github repo must be public
- [x] bosh create-release must run successfully against all final releases (the blobstore needs to be public)
  - if not all final releases are valid, specify a `min_version`
- [x] a README explaining what the repo does
- [x] [optional] deployment manifests/ directory contains example manifest
