### PR TITLE
Add cflinuxfs4 compatibility bosh release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -81,6 +81,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/cflinuxfs3-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/cflinuxfs4-compat-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry/cflinuxfs4-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry-incubator/windows2016fs-online-release


### PR DESCRIPTION
The [cflinuxfs4 compatibility bosh
release](https://github.com/cloudfoundry/cflinuxfs4-compat-release) deploys the [cflinuxfs4
rootfs](https://github.com/cloudfoundry/cflinuxfs4). The compatibility release includes Ruby and Python as decided in the RFC [Proposal for Ruby and Python Removal from the cflinuxfs4 Stack with a Deprecation
Period](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0016-python-and-ruby-removal-from-cf-stack.md). This depends on https://github.com/cloudfoundry/community/pull/590

